### PR TITLE
supporting folders in post directories

### DIFF
--- a/lib/jekyll-postfiles.rb
+++ b/lib/jekyll-postfiles.rb
@@ -43,8 +43,11 @@ module Jekyll
       contents = Dir.glob(File.join(postdir, '**', '*')) do |filepath|
         if filepath != postpath
           filedir, filename = File.split(filepath[sitesrcdir.length..-1])
-          site.static_files <<
-            PostFile.new(site, sitesrcdir, filedir, filename, destdir)
+          filereldir, filename = File.split(filepath[postdir.length..-1])
+          if File.file?(filepath)
+           site.static_files <<
+             PostFile.new(site, sitesrcdir, filedir, filename, destdir + filereldir)
+          end
         end
       end
     end


### PR DESCRIPTION
Not only files, but also directories could be supported with this plugin. Fixing issue [#4](https://github.com/nhoizey/jekyll-postfiles/issues/4)