### PR TITLE
copy over subfolders of assets associated with a post too

### DIFF
--- a/lib/jekyll-postfiles.rb
+++ b/lib/jekyll-postfiles.rb
@@ -1,5 +1,6 @@
 require "jekyll-postfiles/version"
 require "jekyll"
+require "pathname"
 
 module Jekyll
 
@@ -34,30 +35,31 @@ module Jekyll
     # post - A Post which may have associated content.
     def copy_post_files(post)
 
-      post_path = post.path
+      post_path = Pathname.new post.path
       site = post.site
-      site_src_dir = site.source
+      site_src_dir = Pathname.new site.source
 
       # Jekyll.logger.warn(
       #   "[PostFiles]",
       #   "Current post: #{post_path[site_src_dir.length..-1]}"
       # )
 
-      post_dir = File.dirname(post_path)
-      dest_dir = File.dirname(post.destination(""))
+      post_dir = post_path.dirname
+      dest_dir = Pathname.new(post.destination("")).dirname
 
       # Count other Markdown files in the same directory
       other_md_count = 0
-      other_md = Dir.glob(File.join(post_dir, '*.{md,markdown}'), File::FNM_CASEFOLD) do |mdfilepath|
-        if mdfilepath != post_path
+      other_md = Dir.glob(post_dir + '*.{md,markdown}', File::FNM_CASEFOLD) do |mdfilepath|
+        if mdfilepath != post_path.to_path
           other_md_count += 1
         end
       end
 
-      contents = Dir.glob(File.join(post_dir, '*')) do |filepath|
+      contents = Dir.glob(post_dir + '**/*') do |filepath|
         if filepath != post_path \
             && !File.directory?(filepath) \
             && !File.fnmatch?('*.{md,markdown}', filepath, File::FNM_EXTGLOB | File::FNM_CASEFOLD)
+          filepath = Pathname.new(filepath)
           # Jekyll.logger.warn(
           #   "[PostFiles]",
           #   "-> attachment: #{filepath[site_src_dir.length..-1]}"
@@ -68,9 +70,13 @@ module Jekyll
               "Sorry, there can be only one Markdown file in each directory containing other assets to be copied by jekyll-postfiles"
             )
           end
-          filedir, filename = File.split(filepath[site_src_dir.length..-1])
+          relpath = filepath.relative_path_from(site_src_dir)
+          filedir, filename = relpath.dirname, relpath.basename
+
+          absfiledir = site_src_dir + filedir
+          new_dir = absfiledir.relative_path_from(post_dir)
           site.static_files <<
-            PostFile.new(site, site_src_dir, filedir, filename, dest_dir)
+            PostFile.new(site, site_src_dir, filedir, filename, (dest_dir + new_dir).to_path)
         end
       end
     end


### PR DESCRIPTION
fixes #6. This seems to work for me. I don't do any extra checking for markdown files within the subfolders, they simply get stripped out, which I think is better behavior than if it threw an error.