### PR TITLE
Allow depending on Jekyll 4

### DIFF
--- a/jekyll-postfiles.gemspec
+++ b/jekyll-postfiles.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_runtime_dependency "jekyll", "~> 3.6"
+  spec.add_runtime_dependency "jekyll", ">= 3.6"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
C.f. #36.
I have just tried depending not only on the same major version but to any version later than Jekyll 3.6. Quick test shows, it works, despite the additional ignoring work described in #16.